### PR TITLE
Set tray icon as window icon

### DIFF
--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, nativeTheme } from 'electron'
 import { getWindowUrl, buildWindowOptions } from '~/modules/window'
+import { getTrayIcon } from '~/modules/tray-icon'
 
 let window: BrowserWindow | undefined
 
@@ -21,6 +22,7 @@ export function createMainWindow(): BrowserWindow {
   window.on('closed', () => (window = undefined))
   window.removeMenu()
   window.loadURL(getWindowUrl('/'))
+  window.setIcon(getTrayIcon())
 
   return window
 }


### PR DESCRIPTION
Currently, the hackaru desktop application does not set a window icon. At least on Ubuntu this is annoying, because it is hard to figure out which window is the hackaru desktop application.

![without-window-icon](https://user-images.githubusercontent.com/83842/163731862-6ac73a35-9fa8-4592-968e-3ad1d3c18c91.png)

With this PR the hackaru desktop application sets the tray icon as the window icon, which looks like this

![with-window-icon](https://user-images.githubusercontent.com/83842/163731887-bf6d785c-48d4-4ad8-b25c-bbfb64c59a3c.png)

This could be improved by using an image with a higher resolution. However, this solution is currently sufficient for me.